### PR TITLE
fix setup.py for build isolation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ setup(
     description="libssh C library bindings for Python.",
     long_description=open('README.rst').read(),
     install_requires=['abimap'],
+    setup_requires=['abimap'],
     packages=find_packages('.',
                            exclude=('embedded_server', 'embedded_server.*',
                                     'tests', 'tests.*', '*.tests',


### PR DESCRIPTION
setup_requires will probably be deprecated in the future, so we probably should try to move has many things as possible to a pyproject.toml file to comply with the modern way of handling packaging. But this should be done by maintainers of ssh-python upstream.